### PR TITLE
Use encrypted connections by default

### DIFF
--- a/invoke_method.py
+++ b/invoke_method.py
@@ -17,6 +17,7 @@ def init_argparse() -> argparse.ArgumentParser:
         description="Invoke methods on a remote FreeNAS machine.",
     )
     parser.add_argument("-v", "--verbose", action="store_true")
+    parser.add_argument("-i", "--insecure", action="store_true", help="Do not encrypt connection")
     parser.add_argument("method", help="The method to invoke on the remote machine.")
     parser.add_argument(
         "--arguments",
@@ -41,10 +42,10 @@ def init_argparse() -> argparse.ArgumentParser:
 
 
 async def invoke_method(
-    host: str, username: str, password: str, method: str, args: List[Any]
+    host: str, username: str, password: str, secure: bool, method: str, args: List[Any]
 ) -> None:
     print(f"Conencting to {host} to call {method}...")
-    machine = await Machine.create(host=host, username=username, password=password)
+    machine = await Machine.create(host=host, username=username, password=password, secure=secure)
     result = await machine._client.invoke_method(method, args)
     pprint.pprint(result)
 
@@ -60,6 +61,8 @@ if __name__ == "__main__":
     host = args.host
     username = args.username
     password = args.password
+    secure = not args.insecure
+
     try:
         with open(".auth.yaml", "r") as stream:
             data = yaml.safe_load(stream)
@@ -73,6 +76,7 @@ if __name__ == "__main__":
             host=host,
             username=username,
             password=password,
+            secure=secure,
             method=args.method,
             args=json.loads(args.arguments),
         )

--- a/invoke_method.py
+++ b/invoke_method.py
@@ -17,7 +17,9 @@ def init_argparse() -> argparse.ArgumentParser:
         description="Invoke methods on a remote FreeNAS machine.",
     )
     parser.add_argument("-v", "--verbose", action="store_true")
-    parser.add_argument("-i", "--insecure", action="store_true", help="Do not encrypt connection")
+    parser.add_argument(
+        "-i", "--insecure", action="store_true", help="Do not encrypt connection",
+    )
     parser.add_argument("method", help="The method to invoke on the remote machine.")
     parser.add_argument(
         "--arguments",
@@ -44,8 +46,10 @@ def init_argparse() -> argparse.ArgumentParser:
 async def invoke_method(
     host: str, username: str, password: str, secure: bool, method: str, args: List[Any]
 ) -> None:
-    print(f"Conencting to {host} to call {method}...")
-    machine = await Machine.create(host=host, username=username, password=password, secure=secure)
+    print(f"Connecting to {host} to call {method}...")
+    machine = await Machine.create(
+        host=host, username=username, password=password, secure=secure,
+    )
     result = await machine._client.invoke_method(method, args)
     pprint.pprint(result)
 

--- a/pyfreenas/__init__.py
+++ b/pyfreenas/__init__.py
@@ -26,19 +26,23 @@ class Machine(object):
     _info: Dict[str, Any] = {}
 
     @classmethod
-    async def create(cls, host: str, password: str, username: str = "root", secure: bool = True) -> T:
+    async def create(
+        cls, host: str, password: str, username: str = "root", secure: bool = True
+    ) -> T:
         m = Machine()
         await m.connect(host=host, password=password, username=username, secure=secure)
         return m
 
-    async def connect(self, host: str, password: str, username: str, secure: bool) -> None:
+    async def connect(
+        self, host: str, password: str, username: str, secure: bool
+    ) -> None:
         """Connects to the remote machine."""
         assert self._client is None
         if not secure:
-            protocol = 'ws'
+            protocol = "ws"
             context = None
         else:
-            protocol = 'wss'
+            protocol = "wss"
             context = ssl.SSLContext()
         self._client = await websockets.connect(
             f"{protocol}://{host}/websocket",

--- a/tests/test_disk.py
+++ b/tests/test_disk.py
@@ -33,6 +33,7 @@ class TestDisk(IsolatedAsyncioTestCase):
             self._server.host,
             username=self._server.username,
             password=self._server.password,
+            secure=False,
         )
 
     async def asyncTearDown(self):

--- a/tests/test_machine.py
+++ b/tests/test_machine.py
@@ -29,6 +29,7 @@ class TestMachineAuth(IsolatedAsyncioTestCase):
             self._server.host,
             username=self._server.username,
             password=self._server.password,
+            secure=False,
         )
         await machine.close()
 
@@ -38,6 +39,7 @@ class TestMachineAuth(IsolatedAsyncioTestCase):
                 self._server.host,
                 username="not a real user",
                 password=self._server.password,
+                secure=False,
             )
 
 

--- a/tests/test_machine.py
+++ b/tests/test_machine.py
@@ -62,6 +62,7 @@ class TestMachineRefresh(IsolatedAsyncioTestCase):
             self._server.host,
             username=self._server.username,
             password=self._server.password,
+            secure=False,
         )
 
     async def asyncTearDown(self):

--- a/tests/test_virturalmachine.py
+++ b/tests/test_virturalmachine.py
@@ -24,6 +24,7 @@ class TestVirturalMachine(IsolatedAsyncioTestCase):
             self._server.host,
             username=self._server.username,
             password=self._server.password,
+            secure=False,
         )
 
     async def asyncTearDown(self):


### PR DESCRIPTION
I do not allow unencrypted traffic to my FreeNAS servers, so I needed to add support for encrypted connections as my contribution. Let me know what you think.

#### Description:
Use encrypted connections by default. Added (aggressively named) flag *--insecure* to `invoke-method.py` to use an unencrypted connection. Certificates are not validated. They probably should be.

I'd like to add the following to a future update to the SSL functionality: 

https://docs.python.org/3/library/ssl.html#ssl.SSLContext

* ssl_context.verify_mode = ssl.CERT_REQUIRED
* ssl_context.load_cert_chain(some/path/certfile.pem)
* ssl_context.load_default_certs(cert/path)
